### PR TITLE
Feat/fragrance tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ interface Fragrance {
   lastUsed?: string;
   families: OlfactoryFamily[];
   seasons: Season[];
+  tags: string[];
   rating?: 1 | 2 | 3 | 4 | 5;
   comment?: string;
   createdAt: string;

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -125,13 +125,39 @@ git merge feat/add-fragrance
 # Pousser dev sur GitHub
 git push origin dev
 
-# (Optionnel mais propre) Supprimer la branche locale
+# Supprimer la branche locale (mergée, elle ne sert plus)
 git branch -d feat/add-fragrance
 ```
 
 ---
 
-### 5. Créer une Pull Request sur GitHub (interface web)
+### 5. Nettoyer les branches mortes après merge
+
+Une branche mergée ne sert plus. La nettoyer localement et sur GitHub.
+
+```bash
+# Supprimer la branche LOCALE (après merge)
+git branch -d feat/add-fragrance
+
+# Supprimer la branche sur GITHUB (remote)
+git push origin -d feat/add-fragrance
+```
+
+**GitHub le fait aussi** : sur la page de la PR mergée, un bouton "Delete branch"
+apparaît — il supprime la branche remote. Il reste à supprimer la locale manuellement.
+
+**Branches locales mortes en une fois** (pratique pour nettoyer après plusieurs merges) :
+```bash
+# Voir ce qui est mergé dans dev
+git branch --merged dev
+
+# Supprimer tout ce qui est mergé (sauf main, dev, et la branche courante)
+git branch --merged dev | grep -v "^\* \|main\|dev" | xargs git branch -d
+```
+
+---
+
+### 6. Créer une Pull Request sur GitHub (interface web)
 
 > Une PR, même en solo, c'est la trace lisible de "voilà ce que j'ai fait et pourquoi".
 
@@ -143,7 +169,7 @@ git branch -d feat/add-fragrance
 
 ---
 
-### 6. Workflow complet — du début à la fin d'une feature
+### 7. Workflow complet — du début à la fin d'une feature
 
 ```
 1. Lire l'issue sur GitHub

--- a/src/components/fragrance/FragranceForm.tsx
+++ b/src/components/fragrance/FragranceForm.tsx
@@ -36,6 +36,7 @@ export function FragranceForm({ onSubmit }: Props) {
       remainingMl: 0,
       families: [],
       seasons: [],
+      tags: [],
     });
     reset();
   }

--- a/src/types/fragrance.ts
+++ b/src/types/fragrance.ts
@@ -35,6 +35,7 @@ export interface Fragrance {
   lastUsed?: string;
   families: OlfactoryFamily[];
   seasons: Season[];
+  tags: string[];
   rating?: 1 | 2 | 3 | 4 | 5;
   comment?: string;
   createdAt: string;


### PR DESCRIPTION
Titre : feat: ajouter le champ tags à l'interface Fragrance

Description :
Étendre le modèle de données avec le champ tags: string[] avant de construire
les features qui en dépendent (vue détaillée, filtres, dirty state).
Un parfum sans tags n'est pas incomplet — le champ est toujours optionnel.

Critères d'acceptance :


Champ tags: string[] ajouté à l'interface Fragrance dans /types/fragrance.ts

Valeur par défaut tags: [] dans le formulaire d'ajout existant

fragranceService compatible (pas de breaking change)


Closes #15